### PR TITLE
Instrument worker latency through exometer, not io:format.

### DIFF
--- a/apps/overseer/src/overseer_wrkr.erl
+++ b/apps/overseer/src/overseer_wrkr.erl
@@ -45,7 +45,7 @@ handle_cast(_Msg, State) ->
 handle_info(report, State = #state{start_time = ST, fsm_state=reporting}) ->
     Now = erlang:system_time(milli_seconds),
     Diff = (Now - ST) / 1000,
-    io:format(user, "DONE! Latency (sec): ~p~n", [Diff]),
+    exometer:update([overseer, wrkr, latency], Diff),
     {stop, normal, State};
 handle_info(timeout, State = #state{fsm_state = polling_order, order_id = OrderID}) ->
     NewState = case orders:status(OrderID) of

--- a/config/sys.config
+++ b/config/sys.config
@@ -27,8 +27,9 @@
  {exometer_core,
   [
    {predefined, [
-                 {[erlang, memory], {function, erlang, memory, [], proplist,
-                                     [total, processes, ets, binary, atom, atom_used]}, []}
+                 {[overseer, wrkr, latency], histogram, []}
+                , {[erlang, memory], {function, erlang, memory, [], proplist,
+                                      [total, processes, ets, binary, atom, atom_used]}, []}
                 , {[erlang, statistics], {function, erlang, statistics, ['$dp'], value,
                                           [run_queue]},
                    []}
@@ -42,6 +43,10 @@
                           {exometer_report_statsd, []}
                          ]},
              {subscribers, [
+                            {exometer_report_tty, [overseer, wrkr, latency], [999]},
+
+                            {exometer_report_statsd, [overseer, wrkr, latency],
+                             [max, min, mean, median, 50, 75, 90, 95, 97, 99, 999, n], 15000},
                             {exometer_report_statsd, [erlang, memory], [], 15000},
                             {exometer_report_statsd, [erlang, statistics], [run_queue], 15000},
                             {exometer_report_statsd, [erlang, system_info],


### PR DESCRIPTION
Signed-off-by: Brian L. Troutwine brian@troutwine.us
